### PR TITLE
feat : 고객데이터 조회 시 탈퇴 회원은 없는 회원으로 인식할 수 있도록 jpa 메서드 변경

### DIFF
--- a/src/main/java/pp/coinwash/user/domain/repository/CustomerRepository.java
+++ b/src/main/java/pp/coinwash/user/domain/repository/CustomerRepository.java
@@ -1,9 +1,14 @@
 package pp.coinwash.user.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import pp.coinwash.user.domain.entity.Customer;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
-	Boolean existsByLoginId(String id);
+	Boolean existsByLoginIdAndDeletedAtIsNull(String id);
+	Optional<Customer> findByCustomerIdAndDeletedAtIsNull(Long id);
+
+
 }

--- a/src/main/java/pp/coinwash/user/service/CustomerService.java
+++ b/src/main/java/pp/coinwash/user/service/CustomerService.java
@@ -36,13 +36,13 @@ public class CustomerService {
 	}
 
 	private void validateId(String Id) {
-		if (customerRepository.existsByLoginId(Id)) {
+		if (customerRepository.existsByLoginIdAndDeletedAtIsNull(Id)) {
 			throw new RuntimeException("이미 존재하는 아이디입니다.");
 		}
 	}
 
 	private Customer validateCustomer(long customerId) {
-		return customerRepository.findById(customerId)
+		return customerRepository.findByCustomerIdAndDeletedAtIsNull(customerId)
 			.orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다."));
 	}
 }

--- a/src/test/java/pp/coinwash/user/service/CustomerServiceTest.java
+++ b/src/test/java/pp/coinwash/user/service/CustomerServiceTest.java
@@ -73,13 +73,13 @@ class CustomerServiceTest {
 	@Test
 	void signUp() {
 		//given
-		when(customerRepository.existsByLoginId(signUpDto.id())).thenReturn(false);
+		when(customerRepository.existsByLoginIdAndDeletedAtIsNull(signUpDto.id())).thenReturn(false);
 
 		//when
 		customerService.signUp(signUpDto);
 
 		//then
-		verify(customerRepository, times(1)).existsByLoginId(signUpDto.id());
+		verify(customerRepository, times(1)).existsByLoginIdAndDeletedAtIsNull(signUpDto.id());
 		verify(customerRepository).save(argThat(customer ->
 			customer.getLoginId().equals(signUpDto.id()) &&
 				customer.getName().equals(signUpDto.name()) &&
@@ -94,14 +94,14 @@ class CustomerServiceTest {
 	@Test
 	void getCustomer() {
 		//given
-		when(customerRepository.findById(anyLong())).thenReturn(Optional.ofNullable(customer));
+		when(customerRepository.findByCustomerIdAndDeletedAtIsNull(anyLong())).thenReturn(Optional.ofNullable(customer));
 
 		//when
 		CustomerResponseDto result = customerService.getCustomer(1L);
 
 		//then
 		assertNotNull(result);
-		verify(customerRepository, times(1)).findById(1L);
+		verify(customerRepository, times(1)).findByCustomerIdAndDeletedAtIsNull(1L);
 		assertEquals(CustomerResponseDto.from(customer), result);
 	}
 
@@ -109,13 +109,13 @@ class CustomerServiceTest {
 	@Test
 	void updateCustomer() {
 		//given
-		when(customerRepository.findById(anyLong())).thenReturn(Optional.ofNullable(customer));
+		when(customerRepository.findByCustomerIdAndDeletedAtIsNull(anyLong())).thenReturn(Optional.ofNullable(customer));
 
 		// when
 		customerService.updateCustomer(1L, updateDto);
 
 		// then
-		verify(customerRepository).findById(1L);
+		verify(customerRepository).findByCustomerIdAndDeletedAtIsNull(1L);
 
 
 		assertEquals(updateDto.phone(), customer.getPhone());
@@ -128,13 +128,13 @@ class CustomerServiceTest {
 	@Test
 	void deleteCustomer() {
 		//given
-		when(customerRepository.findById(anyLong())).thenReturn(Optional.ofNullable(customer));
+		when(customerRepository.findByCustomerIdAndDeletedAtIsNull(anyLong())).thenReturn(Optional.ofNullable(customer));
 
 		//when
 		customerService.deleteCustomer(1L);
 
 		//then
-		verify(customerRepository, times(1)).findById(1L);
+		verify(customerRepository, times(1)).findByCustomerIdAndDeletedAtIsNull(1L);
 
 		// 실제 삭제일자 데이터를 비교하기 위해서는 나노초는 빼고 비교해야 함.
 		assertEquals(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS),


### PR DESCRIPTION
## 🔍 주요 변경 사항
- 고객 회원 가입 시 아이디 중복 체크 시 jpa 메서드에 deletedAt이 null 값 조건 추가 
- 마찬가지로 고객 정보를 가져올 때도 deletedAt이 null 값 조건 추가
---

## 💡 변경 이유

- 탈퇴 회원인 경우 없는 회원과 마찬가지로 인식할 수 있게끔 함. 따라서 탈퇴회원인 경우 deletedAt 값이 있기 때문에 customerId가 존재하면서 deletedAt 값이 null 인경우에만 실제 고객 회원으로 인식할 수 있게끔 함.

---

## 🚀 개선 결과

- 고객 정보 조회하거나 수정 시 탈퇴 회원은 탐색되지 않도록 함. 

---

## 📂 관련 클래스 및 변경 파일

- CustomerRepository
- CustomerService
- CustomerServicetest


