### PR TITLE
refactor : 유효회원 검증 메서드를 따로 private로 선언

### DIFF
--- a/src/main/java/pp/coinwash/user/service/CustomerService.java
+++ b/src/main/java/pp/coinwash/user/service/CustomerService.java
@@ -28,13 +28,8 @@ public class CustomerService {
 	}
 
 	public String signIn(UserSignInDto dto) {
-		Customer customer = validateId(dto.signInId());
 
-		if (!passwordEncoder.matches(dto.password(), customer.getPassword())) {
-			throw new RuntimeException("비밀번호가 일치하지 않습니다.");
-		}
-
-		return jwtProvider.generateToken(UserAuthDto.fromCustomer(customer));
+		return jwtProvider.generateToken(UserAuthDto.fromCustomer(validateId(dto)));
 	}
 
 	public CustomerResponseDto getCustomer(long customerId) {
@@ -51,9 +46,15 @@ public class CustomerService {
 		validateCustomer(customerId).delete();
 	}
 
-	private Customer validateId(String id) {
-		return customerRepository.findByLoginIdAndDeletedAtIsNull(id)
-			.orElseThrow(() -> new RuntimeException("아이디 혹은 비밀번호가 일치하지 않습니다."));
+	private Customer validateId(UserSignInDto dto) {
+		Customer customer =  customerRepository.findByLoginIdAndDeletedAtIsNull(dto.signInId())
+			.orElseThrow(() -> new RuntimeException("일치하는 아이디가 없습니다."));
+
+		if (!passwordEncoder.matches(dto.password(), customer.getPassword())) {
+			throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+		}
+
+		return customer;
 	}
 
 	private void existsId(String id) {


### PR DESCRIPTION
## 🔍 주요 변경 사항

- validateId 메서드를 통해 유효회원 검증 로직을 해당 메서드 내에 포함시킴
  - findByLoginIdAndDeletedAtIsNull jpa 메서드를 통해 유효회원의 아이디인지 검증
  -  비밀번호 일치 여부 검증

---

## 💡 변경 이유

- 유효회원 검증 로직 (아이디 존재 여부, 비밀번호 일치 여부) 를 하나의 메서드 내부에서 처리되도록 하여 단일 책임 원칙에 위배되지 않도록 함.




