### PR TITLE
refactor : 패키지 이름 변경

### DIFF
--- a/src/main/java/pp/coinwash/history/controller/UsageHistoryController.java
+++ b/src/main/java/pp/coinwash/history/controller/UsageHistoryController.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.controller;
+package pp.coinwash.history.controller;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -13,11 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import pp.coinwash.common.dto.PagedResponseDto;
-import pp.coinwash.machine.domain.entity.Machine;
 import pp.coinwash.machine.domain.repository.MachineRepository;
-import pp.coinwash.usage.domain.dto.UsageHistoryRequestDto;
-import pp.coinwash.usage.domain.dto.UsageHistoryResponseDto;
-import pp.coinwash.usage.service.UsageHistoryService;
+import pp.coinwash.history.domain.dto.UsageHistoryRequestDto;
+import pp.coinwash.history.domain.dto.UsageHistoryResponseDto;
+import pp.coinwash.history.service.UsageHistoryService;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/pp/coinwash/history/domain/dto/UsageDryingDto.java
+++ b/src/main/java/pp/coinwash/history/domain/dto/UsageDryingDto.java
@@ -1,7 +1,7 @@
-package pp.coinwash.usage.domain.dto;
+package pp.coinwash.history.domain.dto;
 
 import lombok.Builder;
-import pp.coinwash.usage.domain.type.DryingCourse;
+import pp.coinwash.history.domain.type.DryingCourse;
 
 @Builder
 public record UsageDryingDto(

--- a/src/main/java/pp/coinwash/history/domain/dto/UsageHistoryRequestDto.java
+++ b/src/main/java/pp/coinwash/history/domain/dto/UsageHistoryRequestDto.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.domain.dto;
+package pp.coinwash.history.domain.dto;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/pp/coinwash/history/domain/dto/UsageHistoryResponseDto.java
+++ b/src/main/java/pp/coinwash/history/domain/dto/UsageHistoryResponseDto.java
@@ -1,10 +1,9 @@
-package pp.coinwash.usage.domain.dto;
+package pp.coinwash.history.domain.dto;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import lombok.Builder;
-import pp.coinwash.usage.domain.entity.UsageHistory;
+import pp.coinwash.history.domain.entity.UsageHistory;
 
 @Builder
 public record UsageHistoryResponseDto(

--- a/src/main/java/pp/coinwash/history/domain/dto/UsageWashingDto.java
+++ b/src/main/java/pp/coinwash/history/domain/dto/UsageWashingDto.java
@@ -1,7 +1,7 @@
-package pp.coinwash.usage.domain.dto;
+package pp.coinwash.history.domain.dto;
 
 import lombok.Builder;
-import pp.coinwash.usage.domain.type.WashingCourse;
+import pp.coinwash.history.domain.type.WashingCourse;
 
 @Builder
 public record UsageWashingDto(

--- a/src/main/java/pp/coinwash/history/domain/entity/UsageHistory.java
+++ b/src/main/java/pp/coinwash/history/domain/entity/UsageHistory.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.domain.entity;
+package pp.coinwash.history.domain.entity;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import pp.coinwash.common.entity.BaseEntity;
 import pp.coinwash.machine.domain.entity.Machine;
-import pp.coinwash.usage.domain.dto.UsageHistoryRequestDto;
+import pp.coinwash.history.domain.dto.UsageHistoryRequestDto;
 
 @Entity
 @Getter

--- a/src/main/java/pp/coinwash/history/domain/repository/UsageHistoryRepository.java
+++ b/src/main/java/pp/coinwash/history/domain/repository/UsageHistoryRepository.java
@@ -1,10 +1,10 @@
-package pp.coinwash.usage.domain.repository;
+package pp.coinwash.history.domain.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import pp.coinwash.usage.domain.entity.UsageHistory;
+import pp.coinwash.history.domain.entity.UsageHistory;
 
 public interface UsageHistoryRepository extends JpaRepository<UsageHistory, Long> {
 	Page<UsageHistory> findAllByCustomerId(long customerId, Pageable pageable);

--- a/src/main/java/pp/coinwash/history/domain/type/DryingCourse.java
+++ b/src/main/java/pp/coinwash/history/domain/type/DryingCourse.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.domain.type;
+package pp.coinwash.history.domain.type;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/pp/coinwash/history/domain/type/WashingCourse.java
+++ b/src/main/java/pp/coinwash/history/domain/type/WashingCourse.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.domain.type;
+package pp.coinwash.history.domain.type;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/pp/coinwash/history/service/UsageHistoryService.java
+++ b/src/main/java/pp/coinwash/history/service/UsageHistoryService.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.service;
+package pp.coinwash.history.service;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -6,10 +6,10 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import pp.coinwash.common.dto.PagedResponseDto;
 import pp.coinwash.machine.domain.entity.Machine;
-import pp.coinwash.usage.domain.dto.UsageHistoryRequestDto;
-import pp.coinwash.usage.domain.dto.UsageHistoryResponseDto;
-import pp.coinwash.usage.domain.entity.UsageHistory;
-import pp.coinwash.usage.domain.repository.UsageHistoryRepository;
+import pp.coinwash.history.domain.dto.UsageHistoryRequestDto;
+import pp.coinwash.history.domain.dto.UsageHistoryResponseDto;
+import pp.coinwash.history.domain.entity.UsageHistory;
+import pp.coinwash.history.domain.repository.UsageHistoryRepository;
 
 @Service
 @RequiredArgsConstructor

--- a/src/test/java/pp/coinwash/history/service/UsageHistoryServiceTest.java
+++ b/src/test/java/pp/coinwash/history/service/UsageHistoryServiceTest.java
@@ -1,4 +1,4 @@
-package pp.coinwash.usage.service;
+package pp.coinwash.history.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -21,10 +21,10 @@ import org.springframework.data.domain.Pageable;
 import pp.coinwash.common.dto.PagedResponseDto;
 import pp.coinwash.laundry.domain.entity.Laundry;
 import pp.coinwash.machine.domain.entity.Machine;
-import pp.coinwash.usage.domain.dto.UsageHistoryRequestDto;
-import pp.coinwash.usage.domain.dto.UsageHistoryResponseDto;
-import pp.coinwash.usage.domain.entity.UsageHistory;
-import pp.coinwash.usage.domain.repository.UsageHistoryRepository;
+import pp.coinwash.history.domain.dto.UsageHistoryRequestDto;
+import pp.coinwash.history.domain.dto.UsageHistoryResponseDto;
+import pp.coinwash.history.domain.entity.UsageHistory;
+import pp.coinwash.history.domain.repository.UsageHistoryRepository;
 
 @ExtendWith(MockitoExtension.class)
 class UsageHistoryServiceTest {


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 패키지 이름 변경

---

## 💡 변경 이유

- 사용이 아닌 사용 내역 기능이기 때문에 패키지 이름을 history로 변경



