### PR TITLE
Feat/ 스케쥴러를 통한 사용/예약 종료 시 자동으로 기계 상태 업데이트

### DIFF
--- a/src/main/java/pp/coinwash/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/pp/coinwash/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,21 @@
+package pp.coinwash.config.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+	@Bean
+	public TaskScheduler taskScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(10);
+		scheduler.setThreadNamePrefix("machine-scheduler-");
+		scheduler.initialize();
+		return scheduler;
+	}
+}

--- a/src/main/java/pp/coinwash/machine/service/scheduler/MachineSchedulerService.java
+++ b/src/main/java/pp/coinwash/machine/service/scheduler/MachineSchedulerService.java
@@ -1,0 +1,58 @@
+package pp.coinwash.machine.service.scheduler;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import pp.coinwash.machine.domain.entity.Machine;
+import pp.coinwash.machine.service.UsingMachineService;
+import pp.coinwash.machine.service.redis.MachineRedisService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MachineSchedulerService {
+
+	private final MachineRedisService machineRedisService;
+	private final UsingMachineService usingMachineService;
+	private final TaskScheduler taskScheduler;
+	private final Map<Long, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+	public void scheduleMachine(Machine machine, LocalDateTime endTime) {
+		//기존 스케줄이 있었다면 해당 스케줄 삭제
+		cancelScheduledTask(machine.getMachineId());
+
+		Instant instant = endTime.atZone(ZoneId.systemDefault()).toInstant();
+
+		ScheduledFuture<?> future = taskScheduler.schedule(() -> {
+
+			log.info("사용 가능한 상태로 변경된 기계 ID: {}", machine.getMachineId());
+
+			machineRedisService.resetMachine(machine);
+			usingMachineService.resetStatus(machine.getMachineId());
+
+			scheduledTasks.remove(machine.getMachineId());
+
+		}, instant);
+
+		scheduledTasks.put(machine.getMachineId(), future);
+		log.info("기계 스케줄링 완료: machineId={}, endTime={}", machine.getMachineId(), endTime);
+
+		scheduledTasks.put(machine.getMachineId(), future);
+	}
+
+	public void cancelScheduledTask(Long machineId) {
+		ScheduledFuture<?> future = scheduledTasks.remove(machineId);
+		if (future != null && !future.isDone()) {
+			future.cancel(false);
+		}
+	}
+}


### PR DESCRIPTION
## 🔍 주요 변경 사항

- MachineSchedulerService 를 통해 스케쥴러를 사용하여 기계 사용 종료 시간 혹은 예약 종료 시간에 자동으로 해당 기계가 사용가능한 상태로 변경될 수 있도록 함. 

---

## 💡 변경 이유
- 기계 사용, 예약 종료 시간되었을 때 기계 상태가 사용가능한 상태로 즉시 변경되어야 다른 고객들이 기계 사용현황을 보고 서비스를 이용할 수 있음. 
- TaskScheduler 를 이용하여 설정한 시간이 되었을 때만 특정 로직을 수행할 수 있도록 함. 
- cancelScheduledTask 를 사용하여 만약 이미 스케쥴러에 등록되어 있는데 새롭게 등록되어야 하는 경우 기존데이터를 삭제하고 새롭게 스케쥴러가 등록될 수 있도록 함. 
  - 예를 들어 에약자가 기계를 사용하는 경우, 예약에서 사용으로 기계 상태를 변경하는 것인데  이때 기존 예약 스케쥴을 삭제하고 사용 스케쥴을 등록해야 하기 때문.


---

## 🚀 개선 결과

- 기계 예약 종료, 사용 종료 시 자동으로 기계 상태 업데이트.

---

## 📂 관련 클래스 및 변경 파일

- `MachineSchedulerService`
- `SchedulerConfig`

---



