### PR TITLE
Refactor/ 고객 위도, 경도 정보를 Point 타입으로 저장

### DIFF
--- a/src/main/java/pp/coinwash/user/domain/dto/CustomerResponseDto.java
+++ b/src/main/java/pp/coinwash/user/domain/dto/CustomerResponseDto.java
@@ -20,8 +20,8 @@ public record CustomerResponseDto(
 			.phone(customer.getPhone())
 			.points(customer.getPoints())
 			.address(customer.getAddress())
-			.latitude(customer.getLatitude())
-			.longitude(customer.getLongitude())
+			.latitude(customer.getLocation().getY())
+			.longitude(customer.getLocation().getX())
 			.build();
 	}
 }

--- a/src/main/java/pp/coinwash/user/domain/entity/Customer.java
+++ b/src/main/java/pp/coinwash/user/domain/entity/Customer.java
@@ -2,8 +2,13 @@ package pp.coinwash.user.domain.entity;
 
 import java.time.LocalDateTime;
 
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,8 +41,9 @@ public class Customer extends BaseEntity {
 	private int points;
 
 	private String address;
-	private Double latitude;
-	private Double longitude;
+
+	@Column(columnDefinition = "POINT SRID 4326", nullable = false)
+	private Point location;
 
 	private LocalDateTime deletedAt;
 
@@ -52,16 +58,14 @@ public class Customer extends BaseEntity {
 			.phone(dto.phone())
 			.points(0)
 			.address(dto.address())
-			.latitude(dto.latitude())
-			.longitude(dto.longitude())
+			.location(createPoint(dto.longitude(), dto.latitude()))
 			.build();
 	}
 
 	public void update(CustomerUpdateDto dto) {
 		this.phone = dto.phone();
 		this.address = dto.address();
-		this.latitude = dto.latitude();
-		this.longitude = dto.longitude();
+		this.location = createPoint(dto.longitude(), dto.latitude());
 	}
 
 	public void delete() {
@@ -74,6 +78,11 @@ public class Customer extends BaseEntity {
 
 	public void earnPoints(int points) {
 		this.points += points;
+	}
+
+	private static Point createPoint(double longitude, double latitude) {
+		GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
 	}
 
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 고객 집의 주소 정보를 기존에는 단순히 long 타입으로 위도, 경도 정보를 저장했다면, Point 타입으로 위치정보를 저장하는 것으로 변경

---

## 💡 변경 이유

- Point 타입으로 위치정보 저장 시 공간 연산을 보다 정확하게 할 수 있음. 또한 집 주소 기반으로 세탁소 탐색 시 쿼리에서 사용자 위치를 ST_GeomFromText 로 변환하지 않아도 되기 때문에 쿼리가 간단해짐.

---

## 🚀 개선 결과

- 위치 계산 정확도 증가, 쿼리 단순화

---

## 📂 관련 클래스 및 변경 파일

- Customer
- CustomerResponseDto


