### PR TITLE
chore : Security 허용 경로 추가

### DIFF
--- a/src/main/java/pp/coinwash/security/config/SecurityConfig.java
+++ b/src/main/java/pp/coinwash/security/config/SecurityConfig.java
@@ -50,12 +50,12 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					//TODO 허용할 경로 추가
-					.requestMatchers("/customer/signup", "/owner/signup", "/auth/**", "/", "/index").permitAll()
-					.requestMatchers("/css/**", "/js/**").permitAll()
 					// 페이지 접근은 허용 (토큰 검증은 API에서만)
-					.requestMatchers("/customer/**", "/owner/**").permitAll()
-					.requestMatchers("/api/*/signup", "/api/*/signin",
+					.requestMatchers( "/auth/**", "/", "/index", "/customer/**", "/owner/**").permitAll()
+					// UI 구성을 위한 파일 요청 경로 허용
+					.requestMatchers("/css/**", "/js/**").permitAll()
+					// api 요청 중 권한 허용
+					.requestMatchers("/api/*/signup", "/api/*/signin", "/actuator/health", "/api/sse/unsubscribe",
 						"/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico", "/error", "/api/address").permitAll()
 					.requestMatchers("/api/owner/**").hasAuthority("OWNER")
 					.requestMatchers("/api/customer/**", "/api/point").hasAuthority("CUSTOMER")

--- a/src/main/java/pp/coinwash/security/filter/JwtFilter.java
+++ b/src/main/java/pp/coinwash/security/filter/JwtFilter.java
@@ -141,6 +141,7 @@ public class JwtFilter extends OncePerRequestFilter {
 			|| requestURI.startsWith("/swagger-resources")
 			|| requestURI.startsWith("/webjars/")
 			|| requestURI.equals("/favicon.ico")
+			|| requestURI.equals("/actuator/health")
 			|| requestURI.equals("/")
 			|| requestURI.equals("/api/address")
 			|| requestURI.startsWith("/login")


### PR DESCRIPTION
## 🔍 주요 변경 사항

- api/sse/unsubscribe , /actuator/health 경로 permitAll 으로 변경

---

## 💡 변경 이유

- sse 연결 해제 요청이 들어왔을 때 처음 요청이 들어온 스레드에서는 인증 처리가 잘 되지만 비동기로 연결 해제 작업을 할 때 

---

## 🚀 개선 결과



---

## 📂 관련 클래스 및 변경 파일



---

## ✅ 테스트 시나리오(예정) 



---

## 💡 참고 블로그



--- 

## 🖼️ 스크린샷



