### PR TITLE
Fix/ deletedById 메서드 호출 시 콜백함수 호출 방지

### DIFF
--- a/src/main/java/pp/coinwash/notification/domain/repository/SseEmitterRepository.java
+++ b/src/main/java/pp/coinwash/notification/domain/repository/SseEmitterRepository.java
@@ -2,7 +2,6 @@ package pp.coinwash.notification.domain.repository;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Repository;
@@ -22,25 +21,28 @@ public class SseEmitterRepository {
 		return Optional.ofNullable(emitters.get(customerId));
 	}
 
-	public SseEmitter save(long customerId ,SseEmitter sseEmitter) {
+	public SseEmitter save(long customerId, SseEmitter sseEmitter) {
 
 		// 연결종료 시
 		sseEmitter.onCompletion(() -> {
-			log.info("SSE 연결 종료 : 사용자 Id {}", customerId);
+			log.debug("콜백함수 onCompletion called");
+			log.debug("SSE 연결 종료: 사용자 Id: {}", customerId);
 			deleteById(customerId);
 		});
 
 		//유효기간 만료시
 		sseEmitter.onTimeout(() -> {
+			log.debug("콜백함수 onTimeout called");
 			log.debug("SSE 연결 시간 만료: 사용자 Id: {}", customerId);
-			deleteById(customerId);});
-
-		//클라이언트와 연결이 끊어졌을 때 동작
-		sseEmitter.onError(e -> {
-			log.warn("SSE 연결 오류: 사용자 Id: {}, 원인: {}", customerId, e.getMessage());
 			deleteById(customerId);
 		});
 
+		//클라이언트와 연결이 끊어졌을 때 동작
+		sseEmitter.onError(e -> {
+			log.warn("콜백함수 onError called");
+			log.warn("SSE 연결 오류: 사용자 Id: {}, 원인: {}", customerId, e.getMessage());
+			deleteById(customerId);
+		});
 
 		emitters.put(customerId, sseEmitter);
 		return emitters.get(customerId);
@@ -49,16 +51,11 @@ public class SseEmitterRepository {
 	// 안전하게 SseEmitter 객체 삭제
 	public void deleteById(long customerId) {
 		SseEmitter emitter = emitters.get(customerId);
+
 		if (emitter != null) {
-			try {
-				emitter.complete();
-			} catch (Exception e) {
-				log.warn("SSE 연결 종료 중 오류 발생 : 사용자 Id {}, 원인: {}", customerId, e.getMessage());
-			} finally {
-				emitters.remove(customerId);
-			}
+			log.info("sseEmitter 객체 제거 : 사용자 Id {}", customerId);
+			emitters.remove(customerId);
 		}
 	}
-
 
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 기존 SseEmitterRepository 의 deletedById 메서드 내부에서 emitter.complete() 메서드를 호출하여 콜백함수 onCompletion이 실행되었음. -> deletedById 메서드 호출 시 emitter.complete() 호출 부분을 삭제하고 바로 emitter.remove() 메서드를 통해 map에서 emitter 객체를 삭제하도록 함. 

---

## 💡 변경 이유

- emitter.complete 호출 시 onCompletion 콜백함수가 실행되고 해당 로직에서 또 deletedById 함수를 호출. ->  순환호출이 이루어짐. 
- emitter.complete 메서드 호출 시 비동기로 다른 스레드에서 실행되는데 이 때 권한 검사가 이루어짐. 그러나 다른 스레드에서 실행되는 것이기 때문에 이때는 SecurityContext 정보가 없는 상태임(다른 스레드로 사용자 인증 정보는 전파되지 않음). 따라서 AuthorizationDeniedException이 발생함. 
- 추후 콜백함수가 다시 호출되어 (에러가 발생하거나, 만료시간되거나 다시 complete 메서드가 호출되는 경우)  AuthorizationDeniedException 이 발생한다고 하더라도 서비스 기능에는 영향이 없음. 
  - emitter.complete() 호출 시 내부 동작으로 finally에 콜백함수에 등록된 로직이 실행됨. 따라서 에러가 발생한다고 하더라도 콜백함수에 등록된 로직 (sseEmitter객체 삭제) 이 실행됨. 따라서 문제가 발생하지는 않음.
---

## 🚀 개선 결과

- 명시적으로 sse 연결 해제 시 AuthorizationDeniedException 발생 하지 않음. 

---

## 📂 관련 클래스 및 변경 파일

- SseEmitterRepository

