### PR TITLE
Chore/ 빌드 시 데몬없이 빌드

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ git pull origin master
 
 # 빌드
 echo "🔨 Building application..."
-./gradlew clean build -x test
+./gradlew clean build -x test --no-daemon
 
 # 빌드 결과 확인
 if [ ! -f build/libs/coinwash-*.jar ]; then


### PR DESCRIPTION
## 🔍 주요 변경 사항

- deploy.sh에서 `./gradlew clean build -x test` 명령어에 --no-daemon 옵션 추가
---

## 💡 변경 이유

- 현재 aws ec2에서 가장 저렴한 요금제를 이용중이기 때문에 스펙이 굉장히 저조함. 따라서  daemon 이 백그라운드로 실행 중일 시 메모리 부족으로 인해 빌드에 실패. 
- 또한 하루에 수십번 재빌드를 하지 않기 때문에 굳이 daemon 을 백그라운드로 실행시킬 필요가 없음. 

---

## 🚀 개선 결과

- 메모리 사용량 개선



