### PR TITLE
Refactor/ 레디스 저장 구조 변경

### DIFF
--- a/src/main/java/pp/coinwash/config/redis/RedisConfig.java
+++ b/src/main/java/pp/coinwash/config/redis/RedisConfig.java
@@ -36,9 +36,9 @@ public class RedisConfig {
 			ObjectMapper.DefaultTyping.NON_FINAL
 		);
 
-		// ⭐ JSR310 모듈 등록 (LocalDateTime 등 Java 8 날짜/시간 타입 지원)
+		//JSR310 모듈 등록 (LocalDateTime 등 Java 8 날짜/시간 타입 지원)
 		objectMapper.registerModule(new JavaTimeModule());
-		// ⭐ 날짜를 타임스탬프가 아닌 ISO 형식으로 직렬화
+		//날짜를 타임스탬프가 아닌 ISO 형식으로 직렬화
 		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
 		// 생성자에서 ObjectMapper를 직접 전달

--- a/src/main/java/pp/coinwash/machine/application/MachineManageApplication.java
+++ b/src/main/java/pp/coinwash/machine/application/MachineManageApplication.java
@@ -62,9 +62,9 @@ public class MachineManageApplication {
 	@Transactional
 	public void deleteMachine(long machineId, long ownerId) {
 		try {
-			manageService.deleteMachine(machineId, ownerId);
+			Machine machine = manageService.deleteMachine(machineId, ownerId);
 
-			redisService.deleteMachine(machineId);
+			redisService.deleteMachine(machine);
 
 		} catch (RedisException e) {
 			log.error("기계 {} Redis 데이터 삭제 실패로 전체 롤백", machineId, e);

--- a/src/main/java/pp/coinwash/machine/service/MachineManageService.java
+++ b/src/main/java/pp/coinwash/machine/service/MachineManageService.java
@@ -67,8 +67,12 @@ public class MachineManageService {
 	}
 
 	@Transactional
-	public void deleteMachine(long machineId, long ownerId) {
-		getValidateMachine(machineId, ownerId).delete();
+	public Machine deleteMachine(long machineId, long ownerId) {
+		Machine machine =  getValidateMachine(machineId, ownerId);
+
+		machine.delete();
+
+		return machine;
 	}
 
 

--- a/src/main/java/pp/coinwash/machine/service/redis/MachineRedisService.java
+++ b/src/main/java/pp/coinwash/machine/service/redis/MachineRedisService.java
@@ -2,14 +2,19 @@ package pp.coinwash.machine.service.redis;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import pp.coinwash.machine.domain.dto.MachineRedisDto;
@@ -26,121 +31,234 @@ public class MachineRedisService {
 	private final MachineRepository machineRepository;
 
 	private static final String MACHINE_KEY_PREFIX = "machine:";
-	private static final String LAUNDRY_MACHINES_KEY_PREFIX = "laundry:machines:";
+	// ⭐ Hash 구조로 변경: laundry:machines:{laundryId} -> Hash(machineId -> MachineRedisDto)
+	private static final String LAUNDRY_MACHINES_HASH_PREFIX = "laundry:machines:";
 
-	// 어플리케이션 실행 시 모든 기계 레디스에 저장
-	@PostConstruct
+	@EventListener(ApplicationReadyEvent.class)
+	@Transactional(readOnly = true)
 	public void initializeMachineData() {
-		List<Machine> machines = machineRepository.findAll();
+		try {
+			log.info("Redis 기계 데이터 초기화 시작...");
 
-		for (Machine machine : machines) {
-			saveMachineToRedis(machine);
+			List<Machine> machines = machineRepository.findAll();
+
+			//세탁소별로 그룹화해서 Hash로 한 번에 저장
+			Map<Long, List<Machine>> machinesByLaundry = machines.stream()
+				.collect(Collectors.groupingBy(m -> m.getLaundry().getLaundryId()));
+
+			for (Map.Entry<Long, List<Machine>> entry : machinesByLaundry.entrySet()) {
+				saveMachinesHashToRedis(entry.getKey(), entry.getValue());
+			}
+
+			log.info("저장된 기계 수: {}, 세탁소 수: {}", machines.size(), machinesByLaundry.size());
+		} catch (Exception e) {
+			log.error("Redis 초기화 실패: {}", e.getMessage(), e);
+		}
+	}
+
+	// ⭐ 세탁소별 기계들을 Hash로 한 번에 저장
+	private void saveMachinesHashToRedis(Long laundryId, List<Machine> machines) {
+		String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + laundryId;
+
+		Map<String, Object> machineMap = machines.stream()
+			.collect(Collectors.toMap(
+				m -> m.getMachineId().toString(),
+				MachineRedisDto::from
+			));
+
+		if (!machineMap.isEmpty()) {
+			redisTemplate.opsForHash().putAll(hashKey, machineMap);
 		}
 
-		log.info("저장된 기계 수 : {}", machines.size());
+		// 개별 키도 유지 (기존 로직 호환성을 위해)
+		for (Machine machine : machines) {
+			String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
+			redisTemplate.opsForValue().set(machineKey, MachineRedisDto.from(machine));
+		}
 	}
 
 	public void saveMachineToRedis(Machine machine) {
 		MachineRedisDto dto = MachineRedisDto.from(machine);
 
-		// 기계 개별 정보 저장
+		// 개별 키 저장 (기존 로직)
 		String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
 		redisTemplate.opsForValue().set(machineKey, dto);
 
-		// 세탁소별 기계 목록에 추가
-		String laundryMachinesKey = LAUNDRY_MACHINES_KEY_PREFIX + machine.getLaundry().getLaundryId();
-		redisTemplate.opsForSet().add(laundryMachinesKey, machine.getMachineId().toString());
+		// Hash에도 저장
+		String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + machine.getLaundry().getLaundryId();
+		redisTemplate.opsForHash().put(hashKey, machine.getMachineId().toString(), dto);
+	}
+
+	// 핵심 최적화: Hash 기반 조회
+	public List<MachineRedisDto> getMachinesByLaundryId(Long laundryId) {
+		long totalStart = System.nanoTime();
+
+		String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + laundryId;
+
+		// 1) Hash의 모든 값을 한 번에 조회 (Set members + MultiGet → Hash values)
+		long hStart = System.nanoTime();
+		List<Object> values = redisTemplate.opsForHash().values(hashKey);
+		long hEnd = System.nanoTime();
+
+		log.info("[perf] phase=hashValues laundryId={} count={} timeMs={}",
+			laundryId, values.size(), ms(hStart, hEnd));
+
+		if (values.isEmpty()) {
+			log.info("[perf] phase=total laundryId={} status=EMPTY_HASH timeMs={}",
+				laundryId, ms(totalStart, System.nanoTime()));
+			return List.of();
+		}
+
+		// 2) 만료 검사 및 결과 생성
+		long eStart = System.nanoTime();
+		LocalDateTime now = LocalDateTime.now();
+		List<MachineRedisDto> result = new ArrayList<>();
+		Map<String, Object> toUpdate = new HashMap<>();
+
+		for (Object value : values) {
+			if (!(value instanceof MachineRedisDto dto)) continue;
+
+			if (needsReset(dto, now)) {
+				dto.reset();
+				toUpdate.put(dto.getMachineId().toString(), dto);
+			}
+			result.add(dto);
+		}
+		long eEnd = System.nanoTime();
+
+		log.info("[perf] phase=expireCheck laundryId={} total={} mutated={} timeMs={}",
+			laundryId, values.size(), toUpdate.size(), ms(eStart, eEnd));
+
+		// 3) 변경된 것만 Hash에 업데이트
+		if (!toUpdate.isEmpty()) {
+			long uStart = System.nanoTime();
+			redisTemplate.opsForHash().putAll(hashKey, toUpdate);
+			long uEnd = System.nanoTime();
+
+			log.info("[perf] phase=hashUpdate laundryId={} updated={} timeMs={}",
+				laundryId, toUpdate.size(), ms(uStart, uEnd));
+		}
+
+		long totalEnd = System.nanoTime();
+		log.info("[perf] phase=total laundryId={} returnSize={} timeMs={}",
+			laundryId, result.size(), ms(totalStart, totalEnd));
+
+		return result;
+	}
+
+	// 비동기 업데이트 버전 (더 빠른 조회)
+	public List<MachineRedisDto> getMachinesByLaundryIdAsync(Long laundryId) {
+		String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + laundryId;
+		List<Object> values = redisTemplate.opsForHash().values(hashKey);
+
+		if (values.isEmpty()) {
+			return List.of();
+		}
+
+		LocalDateTime now = LocalDateTime.now();
+		List<MachineRedisDto> result = new ArrayList<>();
+		Map<String, Object> toUpdate = new HashMap<>();
+
+		for (Object value : values) {
+			if (!(value instanceof MachineRedisDto dto)) continue;
+
+			if (needsReset(dto, now)) {
+				dto.reset();
+				toUpdate.put(dto.getMachineId().toString(), dto);
+			}
+			result.add(dto);
+		}
+
+		// ⭐ 비동기로 업데이트 (조회 성능에 영향 없음)
+		if (!toUpdate.isEmpty()) {
+			CompletableFuture.runAsync(() -> {
+				try {
+					redisTemplate.opsForHash().putAll(hashKey, toUpdate);
+					log.debug("비동기 Hash 업데이트 완료: laundryId={}, count={}", laundryId, toUpdate.size());
+				} catch (Exception e) {
+					log.warn("비동기 Hash 업데이트 실패: laundryId={}, error={}", laundryId, e.getMessage());
+				}
+			});
+		}
+
+		return result;
 	}
 
 	public void updateMachine(Machine machine) {
+		MachineRedisDto dto = MachineRedisDto.from(machine);
+
+		// 개별 키 업데이트
 		String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
+		redisTemplate.opsForValue().set(machineKey, dto);
 
-		MachineRedisDto machineRedis = getMachineRedisDto(machine);
-
-		machineRedis.updateMachine(machine);
-
-		redisTemplate.opsForValue().set(machineKey, machineRedis);
+		// Hash도 업데이트
+		String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + machine.getLaundry().getLaundryId();
+		redisTemplate.opsForHash().put(hashKey, machine.getMachineId().toString(), dto);
 	}
 
 	public void deleteMachine(long machineId) {
 		String machineKey = MACHINE_KEY_PREFIX + machineId;
 
+		// 삭제 전에 laundryId 조회
+		MachineRedisDto dto = (MachineRedisDto) redisTemplate.opsForValue().get(machineKey);
+
+		if (dto != null && dto.getLaundryId() != null) {
+			// Hash에서 삭제
+			String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + dto.getLaundryId();
+			redisTemplate.opsForHash().delete(hashKey, String.valueOf(machineId));
+			log.debug("Hash에서 기계 삭제: laundryId={}, machineId={}", dto.getLaundryId(), machineId);
+		}
+
+		// 개별 키 삭제
 		redisTemplate.delete(machineKey);
-	}
-
-	// 세탁소 ID로 기계 목록 조회
-	public List<MachineRedisDto> getMachinesByLaundryId(Long laundryId) {
-		String laundryMachinesKey = LAUNDRY_MACHINES_KEY_PREFIX + laundryId;
-		Set<Object> machineIds = redisTemplate.opsForSet().members(laundryMachinesKey);
-
-		if (machineIds == null || machineIds.isEmpty()) {
-			return Collections.emptyList();
-		}
-
-		List<MachineRedisDto> machines = new ArrayList<>();
-
-		for (Object machineId : machineIds) {
-			String machineKey = MACHINE_KEY_PREFIX + machineId;
-			MachineRedisDto machine = (MachineRedisDto)redisTemplate.opsForValue().get(machineKey);
-			if (machine != null) {
-
-				if (machine.getEndTime() != null
-					&& machine.getEndTime().isBefore(LocalDateTime.now())
-					&& machine.getUsageStatus() != UsageStatus.UNUSABLE) {
-
-					machine.reset();
-				}
-				machines.add(machine);
-			}
-		}
-
-		return machines;
+		log.debug("개별 키 삭제: machineId={}", machineId);
 	}
 
 	public void useMachine(Machine machine) {
-		String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
-
-		MachineRedisDto machineRedis = getMachineRedisDto(machine);
-
-		machineRedis.useMachine(machine.getCustomerId(), machine.getEndTime());
-
-		redisTemplate.opsForValue().set(machineKey, machineRedis);
+		updateMachineState(machine, (dto) ->
+			dto.useMachine(machine.getCustomerId(), machine.getEndTime()));
 	}
 
 	public void reserveMachine(Machine machine) {
-		String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
-
-		MachineRedisDto machineRedis = getMachineRedisDto(machine);
-
-		machineRedis.reserveMachine(machine.getCustomerId());
-
-		redisTemplate.opsForValue().set(machineKey, machineRedis);
+		updateMachineState(machine, (dto) ->
+			dto.reserveMachine(machine.getCustomerId()));
 	}
 
 	public void resetMachine(Machine machine) {
+		updateMachineState(machine, MachineRedisDto::reset);
+	}
+
+	// 상태 업데이트 로직 통합
+	private void updateMachineState(Machine machine, Consumer<MachineRedisDto> updater) {
+		MachineRedisDto dto = getMachineRedisDto(machine);
+		updater.accept(dto);
+
+		// 개별 키와 Hash 모두 업데이트
 		String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
+		String hashKey = LAUNDRY_MACHINES_HASH_PREFIX + machine.getLaundry().getLaundryId();
 
-		MachineRedisDto machineRedis = getMachineRedisDto(machine);
-
-		machineRedis.reset();
-
-		redisTemplate.opsForValue().set(machineKey, machineRedis);
+		redisTemplate.opsForValue().set(machineKey, dto);
+		redisTemplate.opsForHash().put(hashKey, machine.getMachineId().toString(), dto);
 	}
 
 	private MachineRedisDto getMachineRedisDto(Machine machine) {
 		String machineKey = MACHINE_KEY_PREFIX + machine.getMachineId();
-		String laundryMachinesKey = LAUNDRY_MACHINES_KEY_PREFIX + machine.getLaundry().getLaundryId();
-
-		MachineRedisDto dto = (MachineRedisDto)redisTemplate.opsForValue().get(machineKey);
+		MachineRedisDto dto = (MachineRedisDto) redisTemplate.opsForValue().get(machineKey);
 
 		if (dto == null) {
 			log.warn("Redis에서 기계 데이터 누락 감지, 재생성: machineId={}", machine.getMachineId());
-
-			// 세탁소별 기계 목록에도 추가 (누락 방지)
-			redisTemplate.opsForSet().add(laundryMachinesKey, machine.getMachineId().toString());
 			return MachineRedisDto.from(machine);
-		} else {
-			return dto;
 		}
+		return dto;
+	}
+
+	private boolean needsReset(MachineRedisDto dto, LocalDateTime now) {
+		return dto.getEndTime() != null
+			&& dto.getEndTime().isBefore(now)
+			&& dto.getUsageStatus() != UsageStatus.UNUSABLE;
+	}
+
+	private String ms(long start, long end) {
+		return String.format("%.3f", (end - start) / 1_000_000.0);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,16 @@ spring:
       host: ${REDIS_HOST:redis}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+      timeout: 20000ms
+      connect-timeout: 5000ms
+      lettuce:
+        pool:
+          max-active: 100
+          max-idle: 50
+          min-idle: 5
+          max-wait: 3000ms
+        shutdown-timeout: 100ms
+
 
 kakao:
   api:

--- a/src/test/java/pp/coinwash/machine/application/MachineManageApplicationTest.java
+++ b/src/test/java/pp/coinwash/machine/application/MachineManageApplicationTest.java
@@ -106,7 +106,7 @@ class MachineManageApplicationTest {
 
 		// Then
 		verify(manageService).deleteMachine(machineId, ownerId);
-		verify(redisService).deleteMachine(machineId); // Redis 삭제 확인
+		verify(redisService).deleteMachine(machine); // Redis 삭제 확인
 	}
 
 }

--- a/src/test/java/pp/coinwash/machine/application/MachinePerformanceTest.java
+++ b/src/test/java/pp/coinwash/machine/application/MachinePerformanceTest.java
@@ -1,0 +1,640 @@
+package pp.coinwash.machine.application;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import pp.coinwash.machine.domain.dto.MachineResponseDto;
+import pp.coinwash.machine.service.redis.MachineRedisService;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ActiveProfiles("performance")
+class WeekendPeakTimePerformanceTest {
+
+	@Autowired
+	private MachineApplication machineApplication;
+
+	@Autowired
+	private MachineRedisService redisService;
+
+	private static final Logger log = LoggerFactory.getLogger(WeekendPeakTimePerformanceTest.class);
+
+	// 실제 데이터 규모에 맞춘 테스트 데이터
+	private static final List<Long> POPULAR_LAUNDRY_IDS = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L,
+		11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L);
+
+	// 주말 피크 타임 시나리오 설정
+	private static final int PEAK_CONCURRENT_USERS = 4000; // 400~500명 중간값
+	private static final int REQUESTS_PER_USER = 3; // 사용자당 평균 3번 조회
+	private static final int TOTAL_REQUESTS = PEAK_CONCURRENT_USERS * REQUESTS_PER_USER;
+
+	// 테스트 시나리오별 설정
+	private static final int WARMUP_ITERATIONS = 200;
+	private static final int SUSTAINED_LOAD_DURATION_SECONDS = 30; // 30초간 지속 부하
+
+	@Test
+	@Order(1)
+	@DisplayName("🏪 실제 데이터 규모 확인 및 캐시 상태 점검")
+	void checkDataScaleAndCacheStatus() {
+		log.info("=== 실제 데이터 규모 및 캐시 상태 확인 ===");
+
+		// 실제 데이터 규모 확인
+		log.info("📊 데이터 규모:");
+		log.info("   - 고객 데이터: ~100,000개");
+		log.info("   - 세탁소 데이터: ~1,000개");
+		log.info("   - 기기 데이터: ~10,000개");
+
+		// Redis 캐시 상태 확인
+		Map<String, Object> stats = machineApplication.getRedisStats(POPULAR_LAUNDRY_IDS);
+
+		log.info("🔄 Redis 캐시 통계:");
+		log.info("   - 테스트 대상 세탁소: {}", POPULAR_LAUNDRY_IDS.size());
+		log.info("   - 캐시된 세탁소: {}", stats.get("cachedLaundries"));
+		log.info("   - 캐시 히트율: {}%", String.format("%.1f", (Double) stats.get("cacheHitRate")));
+		log.info("   - 캐시된 총 기계 수: {}", stats.get("totalCachedMachines"));
+
+		double hitRate = (Double) stats.get("cacheHitRate");
+		if (hitRate < 95.0) {
+			log.warn("⚠️ 캐시 히트율이 {}%로 낮습니다. 피크 타임 테스트 정확도에 영향을 줄 수 있습니다.",
+				String.format("%.1f", hitRate));
+		} else {
+			log.info("✅ 피크 타임 테스트를 위한 캐시가 준비되었습니다.");
+		}
+	}
+
+	@Test
+	@Order(2)
+	@DisplayName("🔥 피크 타임 대비 시스템 워밍업")
+	void peakTimeWarmUp() {
+		log.info("=== 피크 타임 대비 시스템 워밍업 시작 ===");
+
+		// 점진적 부하 증가로 워밍업
+		int[] warmupStages = {10, 50, 100, 200};
+
+		for (int stage : warmupStages) {
+			log.info("워밍업 단계: {}개 동시 요청", stage);
+
+			ExecutorService executor = Executors.newFixedThreadPool(stage);
+			CountDownLatch latch = new CountDownLatch(stage);
+
+			for (int i = 0; i < stage; i++) {
+				executor.submit(() -> {
+					try {
+						Long laundryId = POPULAR_LAUNDRY_IDS.get(
+							ThreadLocalRandom.current().nextInt(POPULAR_LAUNDRY_IDS.size()));
+
+						// Redis와 MySQL 모두 워밍업
+						machineApplication.getMachinesFromRedisOnly(laundryId);
+						machineApplication.getMachinesFromMySQLOnly(laundryId);
+					} catch (Exception e) {
+						// 워밍업 중 에러는 무시
+					} finally {
+						latch.countDown();
+					}
+				});
+			}
+
+			try {
+				latch.await(10, TimeUnit.SECONDS);
+				Thread.sleep(1000); // 단계별 휴식
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+
+			executor.shutdown();
+		}
+
+		// 메모리 정리
+		System.gc();
+		sleep(2000);
+		log.info("=== 피크 타임 워밍업 완료 ===");
+	}
+
+	@Test
+	@Order(3)
+	@DisplayName("🏃‍♂️ 주말 피크 타임 시뮬레이션 - Redis vs MySQL")
+	void weekendPeakTimeSimulation() throws InterruptedException {
+		log.info("=== 주말 피크 타임 시뮬레이션 시작 ===");
+		log.info("시나리오: {}명이 동시에 {}번씩 기기 조회 (총 {}건)",
+			PEAK_CONCURRENT_USERS, REQUESTS_PER_USER, TOTAL_REQUESTS);
+
+		// Redis 피크 타임 테스트
+		log.info("🔴 Redis 피크 타임 테스트 시작...");
+		PeakTimeResult redisResult = simulatePeakTime(
+			machineApplication::getMachinesFromRedisOnly, "Redis");
+
+		// 시스템 안정화
+		sleep(3000);
+
+		// MySQL 피크 타임 테스트
+		log.info("🔵 MySQL 피크 타임 테스트 시작...");
+		PeakTimeResult mysqlResult = simulatePeakTime(
+			machineApplication::getMachinesFromMySQLOnly, "MySQL");
+
+		// 결과 비교
+		printPeakTimeComparison(redisResult, mysqlResult);
+	}
+
+	@Test
+	@Order(4)
+	@DisplayName("⏱️ 지속적 부하 테스트 (30초간)")
+	void sustainedLoadTest() throws InterruptedException {
+		log.info("=== 지속적 부하 테스트 시작 ===");
+		log.info("테스트 시간: {}초, 동시 사용자: {}명", SUSTAINED_LOAD_DURATION_SECONDS, PEAK_CONCURRENT_USERS);
+
+		// Redis 지속 부하 테스트
+		log.info("🔴 Redis 지속 부하 테스트...");
+		SustainedLoadResult redisResult = runSustainedLoadTest(
+			machineApplication::getMachinesFromRedisOnly, "Redis");
+
+		sleep(5000); // 시스템 회복 시간
+
+		// MySQL 지속 부하 테스트
+		log.info("🔵 MySQL 지속 부하 테스트...");
+		SustainedLoadResult mysqlResult = runSustainedLoadTest(
+			machineApplication::getMachinesFromMySQLOnly, "MySQL");
+
+		printSustainedLoadComparison(redisResult, mysqlResult);
+	}
+
+	@Test
+	@Order(5)
+	@DisplayName("📊 실제 사용 패턴 시뮬레이션")
+	void realUsagePatternSimulation() throws InterruptedException {
+		log.info("=== 실제 사용 패턴 시뮬레이션 ===");
+		log.info("패턴: 인기 세탁소 80%, 일반 세탁소 20% 비율로 조회");
+
+		// 실제 사용 패턴: 파레토 법칙 적용 (80:20)
+		List<Long> popularLaundries = POPULAR_LAUNDRY_IDS.subList(0, 8); // 상위 8개
+		List<Long> normalLaundries = POPULAR_LAUNDRY_IDS.subList(8, 20); // 나머지 12개
+
+		// Redis 실사용 패턴 테스트
+		RealPatternResult redisResult = simulateRealUsagePattern(
+			machineApplication::getMachinesFromRedisOnly, "Redis",
+			popularLaundries, normalLaundries);
+
+		sleep(3000);
+
+		// MySQL 실사용 패턴 테스트
+		RealPatternResult mysqlResult = simulateRealUsagePattern(
+			machineApplication::getMachinesFromMySQLOnly, "MySQL",
+			popularLaundries, normalLaundries);
+
+		printRealPatternComparison(redisResult, mysqlResult);
+	}
+
+	// === Helper Methods ===
+
+	private PeakTimeResult simulatePeakTime(
+		Function<Long, List<MachineResponseDto>> operation, String type)
+		throws InterruptedException {
+
+		ExecutorService executor = Executors.newFixedThreadPool(PEAK_CONCURRENT_USERS);
+		CountDownLatch latch = new CountDownLatch(PEAK_CONCURRENT_USERS);
+
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger errorCount = new AtomicInteger(0);
+		AtomicLong totalResponseTime = new AtomicLong(0);
+		AtomicLong minTime = new AtomicLong(Long.MAX_VALUE);
+		AtomicLong maxTime = new AtomicLong(Long.MIN_VALUE);
+
+		List<Long> responseTimes = Collections.synchronizedList(new ArrayList<>());
+
+		long startTime = System.nanoTime();
+
+		// 동시 사용자 시뮬레이션
+		for (int i = 0; i < PEAK_CONCURRENT_USERS; i++) {
+			executor.submit(() -> {
+				try {
+					// 사용자당 여러 번 조회 (실제 사용 패턴)
+					for (int j = 0; j < REQUESTS_PER_USER; j++) {
+						Long laundryId = POPULAR_LAUNDRY_IDS.get(
+							ThreadLocalRandom.current().nextInt(POPULAR_LAUNDRY_IDS.size()));
+
+						long opStart = System.nanoTime();
+						try {
+							List<MachineResponseDto> result = operation.apply(laundryId);
+							long opEnd = System.nanoTime();
+							long opTime = opEnd - opStart;
+
+							if (!result.isEmpty()) {
+								successCount.incrementAndGet();
+								totalResponseTime.addAndGet(opTime);
+								responseTimes.add(opTime);
+
+								updateMinMax(minTime, maxTime, opTime);
+							}
+						} catch (Exception e) {
+							errorCount.incrementAndGet();
+							log.debug("{} 피크타임 조회 실패: {}", type, e.getMessage());
+						}
+
+						// 실제 사용자 행동 시뮬레이션 (약간의 지연)
+						if (j < REQUESTS_PER_USER - 1) {
+							Thread.sleep(ThreadLocalRandom.current().nextInt(100, 500));
+						}
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		long endTime = System.nanoTime();
+		executor.shutdown();
+
+		return new PeakTimeResult(type, endTime - startTime, successCount.get(),
+			errorCount.get(), TOTAL_REQUESTS, totalResponseTime.get(),
+			minTime.get(), maxTime.get(), responseTimes);
+	}
+
+	private SustainedLoadResult runSustainedLoadTest(
+		Function<Long, List<MachineResponseDto>> operation, String type)
+		throws InterruptedException {
+
+		AtomicInteger totalRequests = new AtomicInteger(0);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger errorCount = new AtomicInteger(0);
+		AtomicLong totalResponseTime = new AtomicLong(0);
+
+		List<Double> tpsPerSecond = Collections.synchronizedList(new ArrayList<>());
+
+		ExecutorService executor = Executors.newFixedThreadPool(PEAK_CONCURRENT_USERS);
+		AtomicBoolean running = new AtomicBoolean(true);
+
+		// TPS 측정을 위한 별도 스레드
+		ScheduledExecutorService tpsMonitor = Executors.newSingleThreadScheduledExecutor();
+		AtomicInteger lastSecondCount = new AtomicInteger(0);
+
+		tpsMonitor.scheduleAtFixedRate(() -> {
+			int currentCount = successCount.get();
+			int tps = currentCount - lastSecondCount.get();
+			tpsPerSecond.add((double) tps);
+			lastSecondCount.set(currentCount);
+			log.info("{} TPS: {}", type, tps);
+		}, 1, 1, TimeUnit.SECONDS);
+
+		long startTime = System.nanoTime();
+
+		// 지속적 요청 생성
+		for (int i = 0; i < PEAK_CONCURRENT_USERS; i++) {
+			executor.submit(() -> {
+				while (running.get()) {
+					Long laundryId = POPULAR_LAUNDRY_IDS.get(
+						ThreadLocalRandom.current().nextInt(POPULAR_LAUNDRY_IDS.size()));
+
+					long opStart = System.nanoTime();
+					try {
+						totalRequests.incrementAndGet();
+						List<MachineResponseDto> result = operation.apply(laundryId);
+						long opEnd = System.nanoTime();
+
+						if (!result.isEmpty()) {
+							successCount.incrementAndGet();
+							totalResponseTime.addAndGet(opEnd - opStart);
+						}
+					} catch (Exception e) {
+						errorCount.incrementAndGet();
+					}
+
+					// 실제 사용자 요청 간격 시뮬레이션
+					try {
+						Thread.sleep(ThreadLocalRandom.current().nextInt(50, 200));
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						break;
+					}
+				}
+			});
+		}
+
+		// 지정된 시간 동안 실행
+		Thread.sleep(SUSTAINED_LOAD_DURATION_SECONDS * 1000);
+		running.set(false);
+
+		executor.shutdown();
+		executor.awaitTermination(5, TimeUnit.SECONDS);
+
+		tpsMonitor.shutdown();
+
+		long endTime = System.nanoTime();
+
+		return new SustainedLoadResult(type, endTime - startTime,
+			totalRequests.get(), successCount.get(),
+			errorCount.get(), totalResponseTime.get(), tpsPerSecond);
+	}
+
+	private RealPatternResult simulateRealUsagePattern(
+		Function<Long, List<MachineResponseDto>> operation, String type,
+		List<Long> popularLaundries, List<Long> normalLaundries)
+		throws InterruptedException {
+
+		ExecutorService executor = Executors.newFixedThreadPool(PEAK_CONCURRENT_USERS);
+		CountDownLatch latch = new CountDownLatch(PEAK_CONCURRENT_USERS);
+
+		AtomicInteger popularRequests = new AtomicInteger(0);
+		AtomicInteger normalRequests = new AtomicInteger(0);
+		AtomicLong popularResponseTime = new AtomicLong(0);
+		AtomicLong normalResponseTime = new AtomicLong(0);
+
+		long startTime = System.nanoTime();
+
+		for (int i = 0; i < PEAK_CONCURRENT_USERS; i++) {
+			executor.submit(() -> {
+				try {
+					for (int j = 0; j < REQUESTS_PER_USER; j++) {
+						// 80:20 비율로 세탁소 선택
+						boolean isPopular = ThreadLocalRandom.current().nextDouble() < 0.8;
+						Long laundryId;
+
+						if (isPopular) {
+							laundryId = popularLaundries.get(
+								ThreadLocalRandom.current().nextInt(popularLaundries.size()));
+						} else {
+							laundryId = normalLaundries.get(
+								ThreadLocalRandom.current().nextInt(normalLaundries.size()));
+						}
+
+						long opStart = System.nanoTime();
+						try {
+							List<MachineResponseDto> result = operation.apply(laundryId);
+							long opEnd = System.nanoTime();
+							long opTime = opEnd - opStart;
+
+							if (!result.isEmpty()) {
+								if (isPopular) {
+									popularRequests.incrementAndGet();
+									popularResponseTime.addAndGet(opTime);
+								} else {
+									normalRequests.incrementAndGet();
+									normalResponseTime.addAndGet(opTime);
+								}
+							}
+						} catch (Exception e) {
+							log.debug("{} 실사용패턴 조회 실패: {}", type, e.getMessage());
+						}
+
+						Thread.sleep(ThreadLocalRandom.current().nextInt(100, 300));
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		long endTime = System.nanoTime();
+		executor.shutdown();
+
+		return new RealPatternResult(type, endTime - startTime,
+			popularRequests.get(), normalRequests.get(),
+			popularResponseTime.get(), normalResponseTime.get());
+	}
+
+	private void updateMinMax(AtomicLong minTime, AtomicLong maxTime, long opTime) {
+		long currentMin = minTime.get();
+		while (opTime < currentMin && !minTime.compareAndSet(currentMin, opTime)) {
+			currentMin = minTime.get();
+		}
+
+		long currentMax = maxTime.get();
+		while (opTime > currentMax && !maxTime.compareAndSet(currentMax, opTime)) {
+			currentMax = maxTime.get();
+		}
+	}
+
+	private void printPeakTimeComparison(PeakTimeResult redis, PeakTimeResult mysql) {
+		log.info("🎯 === 주말 피크 타임 성능 비교 결과 ===");
+		log.info("📊 테스트 규모: {}명 동시 접속, 총 {}건 요청", PEAK_CONCURRENT_USERS, TOTAL_REQUESTS);
+
+		log.info("⚡ Redis 결과:");
+		log.info("   - 성공률: {}% ({}/{})",
+			String.format("%.1f", redis.getSuccessRate()),
+			redis.getSuccessCount(),
+			redis.getTotalRequests());
+		log.info("   - 평균 응답시간: {}ms", String.format("%.2f", redis.getAvgResponseTime()));
+		log.info("   - 95% 응답시간: {}ms", String.format("%.2f", redis.getPercentile95()));
+		log.info("   - TPS: {}", String.format("%.0f", redis.getTPS()));
+
+		log.info("💾 MySQL 결과:");
+		log.info("   - 성공률: {}% ({}/{})",
+			String.format("%.1f", mysql.getSuccessRate()),
+			mysql.getSuccessCount(),
+			mysql.getTotalRequests());
+		log.info("   - 평균 응답시간: {}ms", String.format("%.2f", mysql.getAvgResponseTime()));
+		log.info("   - 95% 응답시간: {}ms", String.format("%.2f", mysql.getPercentile95()));
+		log.info("   - TPS: {}", String.format("%.0f", mysql.getTPS()));
+
+		double performanceGain = mysql.getAvgResponseTime() / redis.getAvgResponseTime();
+		double tpsGain = redis.getTPS() / mysql.getTPS();
+
+		log.info("🚀 성능 개선:");
+		log.info("   - 응답시간: {}배 향상", String.format("%.1f", performanceGain));
+		log.info("   - 처리량: {}배 향상", String.format("%.1f", tpsGain));
+		log.info("   - 에러율 차이: Redis {}%, MySQL {}%",
+			String.format("%.2f", redis.getErrorRate()),
+			String.format("%.2f", mysql.getErrorRate()));
+		log.info("=======================================");
+	}
+
+	private void printSustainedLoadComparison(SustainedLoadResult redis, SustainedLoadResult mysql) {
+		log.info("🎯 === 지속적 부하 테스트 결과 ===");
+
+		log.info("⚡ Redis - {}초간 지속 부하:", SUSTAINED_LOAD_DURATION_SECONDS);
+		log.info("   - 총 요청: {}, 성공: {}", redis.getTotalRequests(), redis.getSuccessCount());
+		log.info("   - 평균 TPS: {}", String.format("%.0f", redis.getAverageTPS()));
+		log.info("   - 최대 TPS: {}", String.format("%.0f", redis.getMaxTPS()));
+		log.info("   - 평균 응답시간: {}ms", String.format("%.2f", redis.getAvgResponseTime()));
+
+		log.info("💾 MySQL - {}초간 지속 부하:", SUSTAINED_LOAD_DURATION_SECONDS);
+		log.info("   - 총 요청: {}, 성공: {}", mysql.getTotalRequests(), mysql.getSuccessCount());
+		log.info("   - 평균 TPS: {}", String.format("%.0f", mysql.getAverageTPS()));
+		log.info("   - 최대 TPS: {}", String.format("%.0f", mysql.getMaxTPS()));
+		log.info("   - 평균 응답시간: {}ms", String.format("%.2f", mysql.getAvgResponseTime()));
+
+		log.info("🚀 지속 성능 비교:");
+		log.info("   - TPS 향상: {}배", String.format("%.1f", redis.getAverageTPS() / mysql.getAverageTPS()));
+		log.info("   - 응답시간 개선: {}배", String.format("%.1f", mysql.getAvgResponseTime() / redis.getAvgResponseTime()));
+		log.info("=======================================");
+	}
+
+	private void printRealPatternComparison(RealPatternResult redis, RealPatternResult mysql) {
+		log.info("🎯 === 실제 사용 패턴 시뮬레이션 결과 ===");
+
+		log.info("⚡ Redis 패턴별 성능:");
+		log.info("   - 인기 세탁소 (80%): 평균 {}ms", String.format("%.2f", redis.getPopularAvgTime()));
+		log.info("   - 일반 세탁소 (20%): 평균 {}ms", String.format("%.2f", redis.getNormalAvgTime()));
+
+		log.info("💾 MySQL 패턴별 성능:");
+		log.info("   - 인기 세탁소 (80%): 평균 {}ms", String.format("%.2f", mysql.getPopularAvgTime()));
+		log.info("   - 일반 세탁소 (20%): 평균 {}ms", String.format("%.2f", mysql.getNormalAvgTime()));
+
+		log.info("🚀 패턴별 성능 개선:");
+		log.info("   - 인기 세탁소: {}배 향상", String.format("%.1f", mysql.getPopularAvgTime() / redis.getPopularAvgTime()));
+		log.info("   - 일반 세탁소: {}배 향상", String.format("%.1f", mysql.getNormalAvgTime() / redis.getNormalAvgTime()));
+		log.info("=======================================");
+	}
+
+	private void sleep(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	// === Result Classes ===
+
+	public static class PeakTimeResult {
+		private final String type;
+		private final long totalTime;
+		private final int successCount;
+		private final int errorCount;
+		private final int totalRequests;
+		private final long totalResponseTime;
+		private final long minTime;
+		private final long maxTime;
+		private final List<Long> responseTimes;
+
+		public PeakTimeResult(String type, long totalTime, int successCount, int errorCount,
+			int totalRequests, long totalResponseTime, long minTime, long maxTime,
+			List<Long> responseTimes) {
+			this.type = type;
+			this.totalTime = totalTime;
+			this.successCount = successCount;
+			this.errorCount = errorCount;
+			this.totalRequests = totalRequests;
+			this.totalResponseTime = totalResponseTime;
+			this.minTime = minTime;
+			this.maxTime = maxTime;
+			this.responseTimes = new ArrayList<>(responseTimes);
+		}
+
+		public double getSuccessRate() {
+			return (successCount * 100.0) / totalRequests;
+		}
+
+		public double getErrorRate() {
+			return (errorCount * 100.0) / totalRequests;
+		}
+
+		public double getAvgResponseTime() {
+			return successCount > 0 ? (totalResponseTime / 1_000_000.0) / successCount : 0;
+		}
+
+		public double getTPS() {
+			return successCount * 1000.0 / (totalTime / 1_000_000.0);
+		}
+
+		public double getPercentile95() {
+			if (responseTimes.isEmpty()) return 0;
+
+			List<Long> sorted = new ArrayList<>(responseTimes);
+			sorted.sort(Long::compareTo);
+			int index = (int) Math.ceil(sorted.size() * 0.95) - 1;
+			return sorted.get(Math.max(0, index)) / 1_000_000.0;
+		}
+
+		// Getters
+		public String getType() { return type; }
+		public int getSuccessCount() { return successCount; }
+		public int getTotalRequests() { return totalRequests; }
+	}
+
+	public static class SustainedLoadResult {
+		private final String type;
+		private final long totalTime;
+		private final int totalRequests;
+		private final int successCount;
+		private final int errorCount;
+		private final long totalResponseTime;
+		private final List<Double> tpsPerSecond;
+
+		public SustainedLoadResult(String type, long totalTime, int totalRequests, int successCount,
+			int errorCount, long totalResponseTime, List<Double> tpsPerSecond) {
+			this.type = type;
+			this.totalTime = totalTime;
+			this.totalRequests = totalRequests;
+			this.successCount = successCount;
+			this.errorCount = errorCount;
+			this.totalResponseTime = totalResponseTime;
+			this.tpsPerSecond = new ArrayList<>(tpsPerSecond);
+		}
+
+		public double getAverageTPS() {
+			return tpsPerSecond.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+		}
+
+		public double getMaxTPS() {
+			return tpsPerSecond.stream().mapToDouble(Double::doubleValue).max().orElse(0);
+		}
+
+		public double getAvgResponseTime() {
+			return successCount > 0 ? (totalResponseTime / 1_000_000.0) / successCount : 0;
+		}
+
+		// Getters
+		public int getTotalRequests() { return totalRequests; }
+		public int getSuccessCount() { return successCount; }
+	}
+
+	public static class RealPatternResult {
+		private final String type;
+		private final long totalTime;
+		private final int popularRequests;
+		private final int normalRequests;
+		private final long popularResponseTime;
+		private final long normalResponseTime;
+
+		public RealPatternResult(String type, long totalTime, int popularRequests, int normalRequests,
+			long popularResponseTime, long normalResponseTime) {
+			this.type = type;
+			this.totalTime = totalTime;
+			this.popularRequests = popularRequests;
+			this.normalRequests = normalRequests;
+			this.popularResponseTime = popularResponseTime;
+			this.normalResponseTime = normalResponseTime;
+		}
+
+		public double getPopularAvgTime() {
+			return popularRequests > 0 ? (popularResponseTime / 1_000_000.0) / popularRequests : 0;
+		}
+
+		public double getNormalAvgTime() {
+			return normalRequests > 0 ? (normalResponseTime / 1_000_000.0) / normalRequests : 0;
+		}
+
+		// Getters
+		public String getType() { return type; }
+		public int getPopularRequests() { return popularRequests; }
+		public int getNormalRequests() { return normalRequests; }
+	}
+}

--- a/src/test/java/pp/coinwash/machine/service/redis/MachineRedisServiceTest.java
+++ b/src/test/java/pp/coinwash/machine/service/redis/MachineRedisServiceTest.java
@@ -138,7 +138,7 @@ class MachineRedisServiceTest {
 		machineRedisService.saveMachineToRedis(testMachine);
 
 		// when
-		machineRedisService.deleteMachine(testMachine.getMachineId());
+		machineRedisService.deleteMachine(testMachine);
 
 		// then
 		String machineKey = "machine:" + testMachine.getMachineId();

--- a/src/test/resources/application-performance.yml
+++ b/src/test/resources/application-performance.yml
@@ -1,0 +1,61 @@
+spring:
+  application:
+    name: coinwash
+
+  datasource:
+    # 🔧 환경변수 우선, 없으면 localhost 사용
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/coinwash?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${SPRING_DATASOURCE_USERNAME:user}  # 🔧 테스트용 기본값
+    password: ${MYSQL_PASSWORD:coinwashmysql1015}              # 🔧 테스트용 기본값
+    hikari:
+      maximum-pool-size: 100      # 30 → 100 (3배 증가)
+      minimum-idle: 50            # 15 → 50 (3배 증가)
+      connection-timeout: 10000   # 20초 → 10초 (빠른 실패)
+      idle-timeout: 180000        # 5분 → 3분 (빠른 정리)
+      max-lifetime: 900000        # 30분 → 15분 (빠른 갱신)
+      leak-detection-threshold: 30000  # 60초 → 30초 (빠른 감지)
+
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+
+  jwt:
+    secret: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
+
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}     # 🔧 테스트용 기본값
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:coinwashredis1015}  # 🔧 테스트용 기본값
+      timeout: 1000ms           # 2초 → 1초 (빠른 응답)
+      connect-timeout: 2000ms   # 3초 → 2초 (빠른 연결)
+      lettuce:
+        shutdown-timeout: 1000ms  # 2초 → 1초 (빠른 종료)
+        pool:
+          max-active: 2000        # 200 → 2000 (10배 증가)
+          max-idle: 500           # 50 → 500 (10배 증가)
+          min-idle: 100           # 5 → 100 (20배 증가)
+          max-wait: 5000ms        # 1초 → 5초 (여유 확보)
+
+          # 🔧 성능 최적화 추가
+          test-on-borrow: false   # 빌릴 때 테스트 생략 (속도 향상)
+          test-on-return: false   # 반납 시 테스트 생략
+          test-while-idle: true   # 유휴 시에만 테스트
+
+          time-between-eviction-runs: 10000ms  # 10초마다 정리
+          min-evictable-idle-time: 30000ms     # 30초 유휴 시 제거
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY:70a4efa03827692eeda13eea1c434f88}
+
+server:
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    connection-timeout: 20000

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,8 +24,8 @@ spring:
       port: 6379
       password: coinwashredis1015
 
-jwt:
- secret: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
+  jwt:
+   secret: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
 
 logging:
   level:


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 기존 레디스 저장 구조
  - 개별 기계 정보 (String 구조)
  ex) Key: "machine:machineId" → Value: MachineRedisDto
  - ️세탁소별 기계 ID 목록 (Set 구조)
  ex) "laundry:machines:laundryId" → Value: {1, 2, 3} (기계 ID들의 집합) 
  - 따라서 세탁소의 기계 정보를 조회하기 위해서는 찾고자 하는 세탁소 ID를 가지고  먼저 세탁소별 기계 ID 목록 데이터를 가지고 온 후에 그 목록을 가지고 개별 기계 데이터에 접근하여 정보를 조회해야 함.
  - 또한 아래와 같이 개별 조회하여 N회의 네트워크 호출이 이루어짐
```
    for (Object machineId : machineIds) {
    String machineKey = "machine:" + machineId;
    MachineRedisDto machine = redisTemplate.opsForValue().get(machineKey);
```
- 기존에는 세탁기 조회 시 사용/예약 전적이 있다면 종료시간을 기준으로 상태 업데이트를 했었음. 이때 한 트랜잭션으로 묶여 동작

- 수정 레디스 저장 구조
  - 세탁소별 기계 정보 (Hash 구조) - 메인
    - Key: "laundry:machines:laundryId" 
  └── Field: "1" → Value: MachineRedisDto
  └── Field: "2" → Value: MachineRedisDto  
  └── Field: "3" → Value: MachineRedisDto  
  - Hash에서 모든 기계 정보 한 번에 조회 (1회 네트워크 호출)
  
---

## 💡 변경 이유

- Jmeter를 사용하여 성능 테스트를 진행했을 때 레디스를 통해 조회하는 것이 오히려 응답속도가 느렸음. 알아보니 데이터 저장 구조와 조회 방식이었음.  (이미지 참고)
- 따라서 이를 해결하기 위해 저장 구조와 조회 방식 코드 수정
- Jmeter(가정 환경 동시 접속자 3000명이 각기 다른 세탁소(id 범위: 1~300)를 조회하는 상황)
- mysql 사용 조회 응답 속도
<img width="906" height="499" alt="image" src="https://github.com/user-attachments/assets/4c0bd1c6-fdee-474c-9b68-9d83e2c212fb" />

- 기존 레디스 구조 응답속도
<img width="861" height="499" alt="image" src="https://github.com/user-attachments/assets/54f08b33-d631-4ad1-b94c-aa95ce46733c" />


---

## 🚀 개선 결과
- 응답속도가 현저히 개선되었음 (mysql대비 40% 향상, 기존 레디스 대비80%향상)
<img width="906" height="499" alt="image" src="https://github.com/user-attachments/assets/53635d88-24bc-4ebf-bafd-394db8c71e6e" />






