### PR TITLE
refactor : 인덱스 설정 추가

### DIFF
--- a/src/main/java/pp/coinwash/history/domain/entity/History.java
+++ b/src/main/java/pp/coinwash/history/domain/entity/History.java
@@ -2,6 +2,7 @@ package pp.coinwash.history.domain.entity;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -9,8 +10,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +28,11 @@ import pp.coinwash.history.domain.dto.HistoryRequestDto;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Table(
+	indexes = {
+		@Index(name = "idx_customerId", columnList = "customerId")
+	}
+)
 public class History extends BaseEntity {
 
 	@Id
@@ -35,7 +43,7 @@ public class History extends BaseEntity {
 	@JoinColumn(name = "machine_id", nullable = false)
 	private Machine machine;
 
-	//TODO 추후 인덱스 설정 추가
+	@Column(nullable = false)
 	private long customerId;
 
 	//예약 or 사용 내역

--- a/src/main/java/pp/coinwash/machine/application/MachineApplication.java
+++ b/src/main/java/pp/coinwash/machine/application/MachineApplication.java
@@ -39,7 +39,7 @@ public class MachineApplication {
 		long apiStart = System.nanoTime();
 		//먼저 레디스에서 조회
 		try {
-			//응답속도 체크를 위한 시간 데이터
+			// 응답속도 체크를 위한 시간 데이터
 			long redisStart = System.nanoTime();
 
 			List<MachineResponseDto> redisResult = redisService.getMachinesByLaundryIdAsync(laundryId)

--- a/src/main/java/pp/coinwash/point/domain/entity/PointHistory.java
+++ b/src/main/java/pp/coinwash/point/domain/entity/PointHistory.java
@@ -1,11 +1,14 @@
 package pp.coinwash.point.domain.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,12 +22,18 @@ import pp.coinwash.point.domain.type.PointType;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Table(
+	indexes = {
+		@Index(name = "idx_customerId", columnList = "customerId")
+	}
+)
 public class PointHistory extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long pointHistoryId;
 
+	@Column(nullable = false)
 	private long customerId;
 
 	private int changedPoints;


### PR DESCRIPTION
## 🔍 주요 변경 사항

- History와 PointHistory 엔티티의 컬럼 customerId에 인덱스 설정 추가 

---

## 💡 변경 이유

- PointHistory와 History 내역을 조회할 때 customerId를 기준으로 데이터를 조회함. 왜냐하면 PointHistory, History 데이터를 활용하는 경우는 고객 포인트 내역(PointHsitory) 과 고객 사용 내역 (History)을 조회할 때 밖에 없기 때문임. 
- 그러나 이때 customerId에 인덱스 설정이 되어있지 않았기 때문에 데이터 양이 많아졌을 때 응답이 늦어질 수 있음. 
  - Full table scan을 해야하기 떄문에 
  - 그러나 설정을 통해 인덱스 구조를 B-Tree로 설정하여 Full table scan을 하지 않아도 몇번의 탐색만으로 금방 찾고자 하는 customerId 의 데이터 내역들을 조회할 수 있음.
---

## 🚀 개선 결과

- History 데이터, PointHisotry 데이터가 각각 100,000개 씩 있을 때, 특정 customerId 의 데이터를 조회하는 쿼리를 실행했을 때, 
  - (쿼리 성능 테스트 진행) 
  - History의 경우, 쿼리 응답속도가 19.017ms 에서 0.2975ms 로 약 98.4% 향상
 
<img width="2318" height="52" alt="image" src="https://github.com/user-attachments/assets/b826df7f-5ba3-487a-be56-c8758f655e99" />

<img width="2342" height="52" alt="image" src="https://github.com/user-attachments/assets/ca18bc30-cdbe-4e3f-aa64-186917a02717" />

  - PointHistory의 경우, 15.12ms에서 0.2813ms 로 약 98.2% 향상
<img width="2444" height="52" alt="image" src="https://github.com/user-attachments/assets/254271dd-daa0-483c-a6e7-03adc44b8f94" />
<img width="2442" height="48" alt="image" src="https://github.com/user-attachments/assets/2fd4a05e-e060-4a0b-a008-158b493dd4fa" />
 
--
---

## 📂 관련 클래스 및 변경 파일
- History
- PointHistory
---



